### PR TITLE
Upgrade supported builds to AddressSanitizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 out/
 Projects/
 .vs/
+build/
+.cache/
 
 # Prerequisites
 *.d

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-   
+
 project(GameEngine)
 add_subdirectory(Libraries/Engine)
 add_subdirectory(Libraries/Test)
@@ -9,3 +9,4 @@ if (EXISTS projects.cmake)
 	include(projects.cmake)
 endif()
 include(InstallRequiredSystemLibraries)
+

--- a/Libraries/Engine/BaseGame.cpp
+++ b/Libraries/Engine/BaseGame.cpp
@@ -204,13 +204,17 @@ void BaseGame::Cleanup( )
 {
 	SDL_GL_DeleteContext( m_pContext );
 
+    // These aren't run to allow asan to detect symbols correctly
+#ifndef USING_ASAN
 	SDL_DestroyWindow( m_pWindow );
 	m_pWindow = nullptr;
 
 	//Quit SDL subsystems
-	Mix_Quit( );
-	TTF_Quit( );
-	SDL_Quit( );
+    
+    Mix_Quit();
+	TTF_Quit();
+	SDL_Quit();
+#endif
 
 	// enable console close window button
 	#ifdef _WIN32

--- a/cmake/dae/cmakeprojecttemplate.txt
+++ b/cmake/dae/cmakeprojecttemplate.txt
@@ -7,6 +7,17 @@ projectName.cpp
 
 set_target_properties(projectName PROPERTIES FOLDER Games)
 
+# enable AddressSanitizer on modern platforms
+target_compile_options(projectName PRIVATE
+  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:-static-libstdc++ -static-libasan>
+  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:-fsanitize=leak>
+  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:-fno-omit-frame-pointer>
+)
+
+target_link_options(projectName PRIVATE
+  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:-llsan>
+)
+
 target_include_directories(projectName PUBLIC ${GAME_INCLUDE_PATH})
 target_link_libraries(projectName PUBLIC Core)
 target_link_libraries(projectName PUBLIC OpenGL::GL)

--- a/cmake/dae/dae_utils.cmake
+++ b/cmake/dae/dae_utils.cmake
@@ -41,6 +41,9 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_target_properties(CoreTest Core gtest gtest_main gmock gmock_main PROPERTIES FOLDER HiddenTargets)
 
 
+# tell our code we are using asan
+target_compile_definitions(Core PUBLIC USING_ASAN)
+
 endfunction()
 
 

--- a/cmake/dae/main.cpp
+++ b/cmake/dae/main.cpp
@@ -1,24 +1,28 @@
 #include <ctime>
 #include "GameClassName.h"
 
+#ifdef WIN32
 void StartHeapControl();
-void DumpMemoryLeaks();
+#endif
 
 int main( int argc, char *argv[] )
 {
 	srand(static_cast<unsigned int>(time(nullptr)));
 
+#ifdef WIN32
 	StartHeapControl();
+#endif
 
 	GameClassName* pGame{ new GameClassName{ Window{ "Project name - Name, first name - 1DAEXX", 846.f , 500.f } } };
 	pGame->Run();
 	delete pGame;
 
-	DumpMemoryLeaks();
 	return 0;
 }
 
 
+// only legacy platforms need to run this
+#ifdef _WIN32
 void StartHeapControl()
 {
 #if defined(DEBUG) | defined(_DEBUG)
@@ -32,12 +36,4 @@ void StartHeapControl()
 	//_CrtSetBreakAlloc( 156 );
 #endif
 }
-
-void DumpMemoryLeaks()
-{
-#if defined(DEBUG) | defined(_DEBUG)
-	_CrtDumpMemoryLeaks();
 #endif
-}
-
-


### PR DESCRIPTION
I have implemented support for GCC and Clang's AddressSanitizer, which provides exact line numbers for the memory leaks on supported platforms. If not, it falls back to the legacy Microsoft built-in leak checker.
AddressSanitizer builds run around 2x slower than normal builds, but I did not notice the slowdown on any of the exercises in labs so far. This is significantly faster than using valgrind (though of course valgrind checks a lot more than memory leaks). Despite this, it might be nice to provide an easy toggle for it, but I am unsure how this would be implemented through CMake.